### PR TITLE
Add SSL client certificate support

### DIFF
--- a/lib/rubydora/rest_api_client.rb
+++ b/lib/rubydora/rest_api_client.rb
@@ -4,6 +4,7 @@ module Rubydora
   module RestApiClient
     # Fedora API documentation available at {https://wiki.duraspace.org/display/FCR30/REST+API}
     API_DOCUMENTATION = 'https://wiki.duraspace.org/display/FCR30/REST+API'
+    VALID_CLIENT_OPTIONS = [:user, :password, :timeout, :open_timeout, :ssl_client_cert, :ssl_client_key]
     # Create an authorized HTTP client for the Fedora REST API
     # @param [Hash] config
     # @option config [String] :url
@@ -12,7 +13,10 @@ module Rubydora
     # @return [RestClient::Resource]
     def client config = {}
       config = self.config.merge(config)
-      @client ||= RestClient::Resource.new(config[:url], :user => config[:user], :password => config[:password], :timeout => config[:timeout], :open_timeout => config[:timeout])
+      url = config[:url]
+      config.delete_if { |k,v| not VALID_CLIENT_OPTIONS.include?(k) }
+      config[:open_timeout] ||= config[:timeout]
+      @client ||= RestClient::Resource.new(url, config)
     end
 
     # {include:RestApiClient::API_DOCUMENTATION}

--- a/spec/lib/rest_api_client_spec.rb
+++ b/spec/lib/rest_api_client_spec.rb
@@ -15,6 +15,21 @@ describe Rubydora::RestApiClient do
     @mock_repository.config = { :url => 'http://example.org',:user => 'fedoraAdmin', :password => 'fedoraAdmin'}
   end
 
+  it "should create a REST client" do
+    client = @mock_repository.client
+    
+    client.should be_a_kind_of(RestClient::Resource)
+    client.options[:user].should == 'fedoraAdmin'
+  end
+  
+  it "should create a REST client with a client certificate" do
+    client = @mock_repository.client :ssl_client_cert => OpenSSL::X509::Certificate.new, :ssl_client_key => OpenSSL::PKey::RSA.new
+
+    client.options[:user].should == 'fedoraAdmin'
+    client.options[:ssl_client_cert].should be_a_kind_of(OpenSSL::X509::Certificate)
+    client.options[:ssl_client_key].should be_a_kind_of(OpenSSL::PKey::PKey)
+  end
+
   it "should call nextPID" do
     RestClient::Request.should_receive(:execute).with(hash_including(:url => "http://example.org/objects/nextPID?format=xml"))
     @mock_repository.next_pid


### PR DESCRIPTION
This commit adds support for SSL client certificates to the `RestApiClient` module, and adds a little extra abstraction to make it easier to pass through additional options without being indiscriminate.
