### PR TITLE
optional block to rest-client and support for HEAD on datastream_dissemi...

### DIFF
--- a/lib/rubydora/rest_api_client.rb
+++ b/lib/rubydora/rest_api_client.rb
@@ -206,12 +206,18 @@ module Rubydora
     # @option options [String] :pid
     # @option options [String] :dsid
     # @return [String]
-    def datastream_dissemination options = {}
+    def datastream_dissemination options = {}, &block_response
       pid = options.delete(:pid)
       dsid = options.delete(:dsid)
-      raise "" unless dsid
+      method = options.delete(:method)
+      method ||= :get
+      raise self.class.name + "#datastream_dissemination requires a DSID" unless dsid
       begin
-        return client[url_for(datastream_url(pid, dsid) + "/content", options)].get
+        resource = client[url_for(datastream_url(pid, dsid) + "/content", options)]
+        if block_given?
+          resource.options[:block_response] = block_response
+        end
+        return resource.send(method)
       rescue RestClient::ResourceNotFound => e
         raise e
       rescue => e

--- a/spec/lib/rest_api_client_spec.rb
+++ b/spec/lib/rest_api_client_spec.rb
@@ -119,6 +119,15 @@ describe Rubydora::RestApiClient do
      RestClient::Request.should_receive(:execute).with(hash_including(:url => "http://example.org/objects/mypid/datastreams/aaa/content"))
     @mock_repository.datastream_dissemination :pid => 'mypid', :dsid => 'aaa'
   end
+  it "should allow http methods besides GET on datastream_dissemination" do
+     RestClient::Request.should_receive(:execute).with(hash_including(:method => :head))
+    @mock_repository.datastream_dissemination :pid => 'mypid', :dsid => 'aaa', :method => :head
+  end
+  it "should pass a block to the rest client to process the response in datastream_dissemination" do
+     _proc = lambda { |x| x }
+     RestClient::Request.should_receive(:execute).with(hash_including(:block_response => _proc))
+    @mock_repository.datastream_dissemination :pid => 'mypid', :dsid => 'aaa', &_proc
+  end
   it "should raise not found exception when retrieving datastream_dissemination" do
      RestClient::Request.should_receive(:execute).with(hash_including(:url => "http://example.org/objects/mypid/datastreams/aaa/content")).and_raise( RestClient::ResourceNotFound)
     lambda {@mock_repository.datastream_dissemination :pid => 'mypid', :dsid => 'aaa'}.should raise_error RestClient::ResourceNotFound


### PR DESCRIPTION
These changes allow you to write an iterator the streams the response from datastream_dissemination to the client in Rails 3, rather than reading the whole thing in at once
