### PR TITLE
Export support in the rest api

### DIFF
--- a/lib/rubydora/rest_api_client.rb
+++ b/lib/rubydora/rest_api_client.rb
@@ -92,6 +92,20 @@ module Rubydora
     # @param [Hash] options
     # @option options [String] :pid
     # @return [String]
+    def export options = {}
+      pid = options.delete(:pid)
+      begin
+	return client[export_url(pid, options)].get
+      rescue => e
+        logger.error e.response
+        raise "Error exporting object #{pid}. See logger for details"
+      end
+    end
+
+    # {include:RestApiClient::API_DOCUMENTATION}
+    # @param [Hash] options
+    # @option options [String] :pid
+    # @return [String]
     def modify_object options = {}
       pid = options.delete(:pid)
       begin
@@ -394,6 +408,15 @@ module Rubydora
     def datastream_url pid, dsid = nil, options = nil
       raise "" unless pid
       url_for(object_url(pid) + "/datastreams" + (("/#{CGI::escape(dsid)}" if dsid) || ''), options)
+    end
+
+    # Generate a base export REST API endpoint URI
+    # @param [String] pid
+    # @param [Hash] options to convert to URL parameters
+    # @return [String] URI
+    def export_url pid, options = nil
+      raise "" unless pid
+      url_for(object_url(pid) + "/export", options)
     end
 
   end

--- a/spec/lib/rest_api_client_spec.rb
+++ b/spec/lib/rest_api_client_spec.rb
@@ -72,6 +72,11 @@ describe Rubydora::RestApiClient do
     @mock_repository.ingest :pid => 'mypid'
   end
 
+  it "export" do
+     RestClient::Request.should_receive(:execute).with(hash_including(:url => "http://example.org/objects/mypid/export"))
+    @mock_repository.export :pid => 'mypid'
+  end
+
   it "modify_object" do
      RestClient::Request.should_receive(:execute) do |params|
        params.should have_key(:url)


### PR DESCRIPTION
Added support for export in the rest api along with a simple test in the rest api spec tests.  This appears to work with changes to the format and context options as well as the default.
