### PR TITLE
Make Repository#search handle 401 errors gracefully

### DIFF
--- a/rubydora.gemspec
+++ b/rubydora.gemspec
@@ -32,4 +32,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency("rspec")
   s.add_development_dependency("yard")
   s.add_development_dependency("jettywrapper")
+  s.add_development_dependency("webmock")
 end

--- a/spec/lib/integration_test_spec.rb
+++ b/spec/lib/integration_test_spec.rb
@@ -413,6 +413,18 @@ describe "Integration testing against a live Fedora repository", :integration =>
       pids.should include('test:1', 'test:2')
     end
 
+    it "should skip forbidden objects" do
+      # lets say the object test:2 is forbidden
+      stub = stub_http_request(:get, /.*test:2.*/).to_return(:status => 401)
+      objects = []
+      lambda { objects = @repository.search('pid~test:*') }.should_not raise_error
+      pids = objects.map {|obj| obj.pid }
+      pids.should include('test:1')
+      pids.should_not include('test:2')
+      stub.should have_been_requested
+      WebMock.reset!
+    end
+
   end
 
   it "should not destroy content when datastream properties are changed" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,9 @@ end
 require 'rspec/autorun'
 require 'loggable'
 require 'rubydora'
+require 'webmock/rspec'
+
+WebMock.allow_net_connect!
 
 RSpec.configure do |config|
 


### PR DESCRIPTION
The Fedora search returns all objects which match the given query regardless of whether the searcher has permission to read it. Unfortunately, in our repository some objects are not retrievable because of XACML restrictions, and when rubydora tries to load such an object, RestClient raises a 401 exception, when then terminates the search.

This patch catches the RestClient exception and has the search move on to the next object. Any digital object that generates a 401 error in a search is silently skipped.
