### PR TITLE
Added #object_xml to Rubydora::DigitalObject

### DIFF
--- a/lib/rubydora/digital_object.rb
+++ b/lib/rubydora/digital_object.rb
@@ -160,6 +160,10 @@ module Rubydora
       end
     end
 
+    def object_xml
+      repository.object_xml(pid: pid)
+    end
+
     def versions
       versions_xml = repository.object_versions(:pid => pid)
       versions_xml.gsub! '<fedoraObjectHistory', '<fedoraObjectHistory xmlns="http://www.fedora.info/definitions/1/0/access/"' unless versions_xml =~ /xmlns=/

--- a/spec/lib/digital_object_spec.rb
+++ b/spec/lib/digital_object_spec.rb
@@ -433,4 +433,13 @@ describe Rubydora::DigitalObject do
     it_behaves_like "an object attribute"
     let(:method) { 'lastModifiedDate' }
   end
+
+  describe "#object_xml" do
+    it "should return the FOXML record" do
+      xml = File.read(File.join(File.dirname(__FILE__), '..', 'fixtures', 'audit_trail.foxml.xml'))
+      @mock_repository.stub(:object_xml).with(hash_including(:pid => 'foo:bar')).and_return(xml)
+      @object = Rubydora::DigitalObject.new 'foo:bar', @mock_repository
+      @object.object_xml.should == @object.repository.object_xml(pid: 'foo:bar')
+    end
+  end
 end


### PR DESCRIPTION
Currently, if you want to get the FOXML record for an ActiveFedora object, you have to do this:

``` ruby
obj.inner_object.repository.object_xml(pid: obj.pid)
```

A first step towards a more transparent API would be to add this method to Rubydora::DigitalObject.
