### PR TITLE
Symbolizing define_hooks parameters for Hooks gem

### DIFF
--- a/lib/rubydora/rest_api_client.rb
+++ b/lib/rubydora/rest_api_client.rb
@@ -33,10 +33,10 @@ module Rubydora
 
       include Hooks
       [:ingest, :modify_object, :purge_object, :set_datastream_options, :add_datastream, :modify_datastream, :purge_datastream, :add_relationship, :purge_relationship].each do |h|
-        define_hook "before_#{h}"
+        define_hook "before_#{h}".to_sym
       end
 
-      define_hook "after_ingest"
+      define_hook :after_ingest
       include Transactions
     end
 

--- a/lib/rubydora/transactions.rb
+++ b/lib/rubydora/transactions.rb
@@ -99,7 +99,7 @@ module Rubydora
   class Transaction
     attr_reader :repository
     include Hooks
-    define_hook "after_rollback"
+    define_hook :after_rollback
 
     def initialize repository, &block
       @repository = repository

--- a/rubydora.gemspec
+++ b/rubydora.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "mime-types"
   s.add_dependency "activesupport"
   s.add_dependency "activemodel"
-  s.add_dependency "hooks", "~> 0.2.2"
+  s.add_dependency "hooks", "~> 0.3.0"
   s.add_dependency "deprecation"
 
   s.add_development_dependency("rake")


### PR DESCRIPTION
The API of the Hooks gem changed between 0.2.2 and 0.3.0. These changes
address those changes. It should be noted that Hooks 0.3.0 introduced
the concept of halting the callback chain when false is encountered.
As a warning, this update may create problems for other defined
callbacks.
