### PR TITLE
add handling for fcrepo-3.6 datastreamProfiles API

### DIFF
--- a/lib/rubydora/datastream.rb
+++ b/lib/rubydora/datastream.rb
@@ -286,10 +286,16 @@ module Rubydora
     end
 
     def profile= profile_xml
-      unless profile_xml.eql? @profile_xml
-        @profile_xml = profile_xml
-        @profile = self.profile_xml_to_hash(profile_xml)
+      if (profile_xml.is_a? Nokogiri::XML::Node)
+        @profile_xml = nil
+        @profile = profile_node_to_hash profile_xml
         attribute_will_change! :profile
+      elsif profile_xml.is_a? String 
+        unless profile_xml.eql? @profile_xml
+          @profile_xml = profile_xml
+          @profile = self.profile_xml_to_hash(profile_xml)
+          attribute_will_change! :profile
+        end
       end
     end
 
@@ -299,11 +305,17 @@ module Rubydora
     end
 
     def profile_xml_to_hash profile_xml
-      profile_xml.gsub! '<datastreamProfile', '<datastreamProfile xmlns="http://www.fedora.info/definitions/1/0/management/"' unless profile_xml =~ /xmlns=/
+      #profile_xml.gsub! '<datastreamProfile', '<datastreamProfile xmlns="http://www.fedora.info/definitions/1/0/management/"' unless profile_xml =~ /xmlns=/
       doc = Nokogiri::XML(profile_xml)
-      h = doc.xpath('/management:datastreamProfile/*', {'management' => "http://www.fedora.info/definitions/1/0/management/"} ).inject({}) do |sum, node|
-                   sum[node.name] ||= []
-                   sum[node.name] << node.text
+      # since the profile may be in the management or the access namespace, use the CSS selector
+      node = doc.css('datastreamProfile').first
+      profile_node_to_hash(node)
+    end
+
+    def profile_node_to_hash node
+      h = node.xpath('./*').inject({}) do |sum, c_node|
+                   sum[c_node.name] ||= []
+                   sum[c_node.name] << c_node.text
                    sum
                  end.reject { |key, values| values.empty? }
       h.select { |key, values| values.length == 1 }.each do |key, values|

--- a/lib/rubydora/digital_object.rb
+++ b/lib/rubydora/digital_object.rb
@@ -198,8 +198,8 @@ module Rubydora
           end
           # post-3.6, full ds profiles will be returned
           doc.xpath('//access:datastreamProfile', {'access' => "http://www.fedora.info/definitions/1/0/access/"}).each do |ds|
-            p_xml = ds.to_xml.gsub! 'apim:', ''
-            h[ds['dsID']].initialize_profile p_xml
+            # n.b. that the dsID attribute has a different name in the profile response
+            h[ds['dsID']].initialize_profile ds
           end
         rescue RestClient::ResourceNotFound
         end


### PR DESCRIPTION
In Fedora 3.5, adding the "profiles" param to a listDatastreams request has no effect. In 3.6, it returns the profiles of all the datastreams instead of a simple list of dsId's. Accommodating the latter will save some http request overhead.
