### PR TITLE
Remove ineffective multipart option

### DIFF
--- a/lib/rubydora/rest_api_client.rb
+++ b/lib/rubydora/rest_api_client.rb
@@ -342,7 +342,7 @@ module Rubydora
       run_hook :before_add_datastream, :pid => pid, :dsid => dsid, :file => file, :options => options
       str = file.respond_to?(:read) ? file.read : file
       file.rewind if file.respond_to?(:rewind)
-      client[datastream_url(pid, dsid, query_options)].post(str, :content_type => content_type.to_s, :multipart => true)
+      client[datastream_url(pid, dsid, query_options)].post(str, :content_type => content_type.to_s)
     rescue Exception => exception
         rescue_with_handler(exception) || raise
     end
@@ -363,7 +363,6 @@ module Rubydora
 
       rest_client_options = {}
       if file
-        rest_client_options[:multipart] = true
         rest_client_options[:content_type] = content_type
       end
 


### PR DESCRIPTION
The code looks like it is doing a multipart request, but it isn't. It is just setting the header 'Multipart' to true. I noticed this while capturing requests between an application and Fedora.

Keeping the code as is because changing it to use multipart encoding with a PUT method triggers a Fedora bug. (see https://jira.duraspace.org/browse/FCREPO-1206).
