### PR TITLE
batch fetching profiles in Fedora 3.6+

### DIFF
--- a/lib/rubydora/digital_object.rb
+++ b/lib/rubydora/digital_object.rb
@@ -154,13 +154,19 @@ module Rubydora
         h = Hash.new { |h,k| h[k] = datastream_object_for(k) }                
 
         begin
-          options = { :pid => pid }
+          options = { :pid => pid, :profiles => 'true' }
           options[:asOfDateTime] = asOfDateTime if asOfDateTime
           datastreams_xml = repository.datastreams(options)
+          # pre-3.6, the profiles parm will be ignored
           datastreams_xml.gsub! '<objectDatastreams', '<objectDatastreams xmlns="http://www.fedora.info/definitions/1/0/access/"' unless datastreams_xml =~ /xmlns=/
           doc = Nokogiri::XML(datastreams_xml)
           doc.xpath('//access:datastream', {'access' => "http://www.fedora.info/definitions/1/0/access/"}).each do |ds| 
             h[ds['dsid']] = datastream_object_for ds['dsid'] 
+          end
+          # post-3.6, full ds profiles will be returned
+          doc.xpath('//access:datastreamProfile', {'access' => "http://www.fedora.info/definitions/1/0/access/"}).each do |ds|
+            # n.b. that the dsID attribute has a different name in the profile response
+            h[ds['dsID']] = datastream_object_for(ds['dsID'], {:profile => ProfileParser.hash_datastream_profile_node(ds)})
           end
         rescue RestClient::ResourceNotFound
         end

--- a/lib/rubydora/fc3_service.rb
+++ b/lib/rubydora/fc3_service.rb
@@ -59,7 +59,7 @@ module Rubydora
         raise e
       rescue RestClient::ResourceNotFound
         # the datastream is new
-        ''
+        return {}
       end
 
       ProfileParser.parse_datastream_profile(xml)


### PR DESCRIPTION
Add the parameter for including DS profiles in the DS listing REST request, and use the CSS selector to build the profile hash since the NS for datastreamProfile is different in the two contexts.
