### PR TITLE
When fedora object is modified, lastModifiedDate should reflect the change

### DIFF
--- a/lib/rubydora/digital_object.rb
+++ b/lib/rubydora/digital_object.rb
@@ -197,7 +197,10 @@ module Rubydora
           @profile = nil #will cause a reload with updated data
         else                       
           p = to_api_params
-          repository.modify_object p.merge(:pid => pid) unless p.empty?
+          unless p.empty?
+            mod_time = repository.modify_object p.merge(:pid => pid)
+            self.lastModifiedDate = mod_time
+          end
         end
       end
 

--- a/spec/lib/digital_object_spec.rb
+++ b/spec/lib/digital_object_spec.rb
@@ -296,6 +296,20 @@ describe Rubydora::DigitalObject do
       @mock_repository.should_receive(:modify_object).with(hash_including(:pid => 'pid'))
       @object.save
     end
+
+    it "updates the modification time" do
+      ds = double(Rubydora::Datastream)
+      ds.stub(:changed? => false)
+      @object.stub(:datastreams) { { :ds => ds } }
+
+      mod_time = Time.local(2012, 1, 2, 5, 15, 45).to_s
+      @mock_repository.should_receive(:modify_object).and_return(mod_time)
+
+      @object.lastModifiedDate = 'old time'
+      @object.save
+      @object.lastModifiedDate.should == mod_time
+    end
+
   end
 
   describe "delete" do


### PR DESCRIPTION
This commit is an attempt to address the problem described in issue 351 of the active-fedora gem:
https://github.com/projecthydra/active_fedora/issues/351
