### PR TITLE
Delegate :datastream_url to :api in Rubydora::Repository

### DIFF
--- a/lib/rubydora/repository.rb
+++ b/lib/rubydora/repository.rb
@@ -17,7 +17,7 @@ module Rubydora
     end
 
     delegate :client, :transaction, :mint, :ingest, :find_objects, :purge_object,
-      :modify_object, :datastreams, :add_datastream, :modify_datastream,
+      :modify_object, :datastream_url, :datastreams, :add_datastream, :modify_datastream,
       :set_datastream_options, :datastream_dissemination, :purge_datastream,
       :add_relationship, :purge_relationship, :repository_profile,
       :object_profile, :datastream_profile, :versions_for_datastream,

--- a/spec/lib/repository_spec.rb
+++ b/spec/lib/repository_spec.rb
@@ -100,4 +100,11 @@ describe Rubydora::Repository do
     end
   end
 
+  describe "delegation of methods to api" do
+    it "should delegate :datastream_url" do
+      @repository.api.should_receive(:datastream_url).with("foo:bar", "descMetadata", {})
+      @repository.datastream_url("foo:bar", "descMetadata", {})
+    end
+  end
+
 end


### PR DESCRIPTION
Fixes #66
