### PR TITLE
fix unit tests to use repository and api objects

### DIFF
--- a/lib/rubydora/repository.rb
+++ b/lib/rubydora/repository.rb
@@ -31,8 +31,9 @@ module Rubydora
     # @option options [String] :user
     # @option options [String] :password
     # @option options [Boolean] :validateChecksum
-    def initialize options = {}
+    def initialize options = {}, api = nil
       @config = options.symbolize_keys
+      @api = api if api
       check_repository_version!
     end
 


### PR DESCRIPTION
unit testing directly against the api object prevents testing delegation
