### PR TITLE
rubydora-72: Make use of ds profiles on create and update

### DIFF
--- a/lib/rubydora/datastream.rb
+++ b/lib/rubydora/datastream.rb
@@ -290,8 +290,9 @@ module Rubydora
     def create
       check_if_read_only
       run_callbacks :create do
-        repository.add_datastream to_api_params.merge({ :pid => pid, :dsid => dsid, :content => content })
+        p = repository.add_datastream( to_api_params.merge({ :pid => pid, :dsid => dsid, :content => content })) || {}
         reset_profile_attributes
+        self.profile= p unless p.empty?
         self.class.new(digital_object, dsid, @options)
       end
     end
@@ -303,8 +304,9 @@ module Rubydora
       run_callbacks :save do
         raise RubydoraError.new("Unable to save #{self.inspect} without content") unless has_content?
         return create if new?
-        repository.modify_datastream to_api_params.merge({ :pid => pid, :dsid => dsid })
+        p = repository.modify_datastream(to_api_params.merge({ :pid => pid, :dsid => dsid })) || {}
         reset_profile_attributes
+        self.profile= p unless p.empty?
         self.class.new(digital_object, dsid, @options)
       end
     end

--- a/lib/rubydora/profile_parser.rb
+++ b/lib/rubydora/profile_parser.rb
@@ -79,6 +79,12 @@ module Rubydora
         input
       end
     end
-
+    def self.canonicalize_date(input)
+      if input.is_a? Time
+        canonicalize_date_string(input.utc.strftime("%Y-%m-%dT%H:%M:%S.%3NZ"))
+      else
+        canonicalize_date_string(input.to_s)
+      end
+    end
   end
 end

--- a/lib/rubydora/rest_api_client.rb
+++ b/lib/rubydora/rest_api_client.rb
@@ -340,7 +340,7 @@ module Rubydora
       run_hook :before_add_datastream, :pid => pid, :dsid => dsid, :file => file, :options => options
       str = file.respond_to?(:read) ? file.read : file
       file.rewind if file.respond_to?(:rewind)
-      client[datastream_url(pid, dsid, query_options)].post(str, :content_type => content_type.to_s, :multipart => true)
+      ProfileParser.parse_datastream_profile(client[datastream_url(pid, dsid, query_options)].post(str, :content_type => content_type.to_s, :multipart => true))
     rescue Exception => exception
         rescue_with_handler(exception) || raise
     end
@@ -365,7 +365,7 @@ module Rubydora
       run_hook :before_modify_datastream, :pid => pid, :dsid => dsid, :file => file, :content_type => content_type, :options => options
       str = file.respond_to?(:read) ? file.read : file
       file.rewind if file.respond_to?(:rewind)
-      client[datastream_url(pid, dsid, query_options)].put(str, rest_client_options)
+      ProfileParser.parse_datastream_profile(client[datastream_url(pid, dsid, query_options)].put(str, rest_client_options))
 
     rescue Exception => exception
         rescue_with_handler(exception) || raise

--- a/spec/lib/datastream_spec.rb
+++ b/spec/lib/datastream_spec.rb
@@ -385,7 +385,7 @@ describe Rubydora::Datastream do
   describe "update" do
     before(:each) do
       @datastream = Rubydora::Datastream.new @mock_object, 'dsid'
-      @mock_api.stub(:datastream).and_return <<-XML
+      @mock_api.should_receive(:datastream).once.and_return <<-XML
         <datastreamProfile>
           <dsLocation>some:uri</dsLocation>
           <dsLabel>label</dsLabel>
@@ -416,9 +416,10 @@ describe Rubydora::Datastream do
 
     describe "update when content is changed" do
       it "should update the datastream when the content is changed" do
-        @mock_api.should_receive(:modify_datastream).with(hash_including(:content => 'test'))
+        @mock_api.should_receive(:modify_datastream).with(hash_including(:content => 'test')).and_return({'dsLocation' => 'some:uri', 'dsLabel' => 'label', 'dsSize' => 4})
         @datastream.content = "test"
         @datastream.save
+        @datastream.dsSize.should == 4
       end
 
       it "should be marked as changed when the content is updated" do

--- a/spec/lib/digital_object_spec.rb
+++ b/spec/lib/digital_object_spec.rb
@@ -243,17 +243,17 @@ describe Rubydora::DigitalObject do
     describe "saving an object's datastreams" do
       before do
         @new_ds = double(Rubydora::Datastream)
-        @new_ds.stub(:new? => true, :changed? => true, :content_changed? => true, :content => 'XXX')
+        @new_ds.stub(:new? => true, :changed? => true, :content_changed? => true, :content => 'XXX', :dsCreateDate => '12345')
         @new_empty_ds = double(Rubydora::Datastream)
-        @new_empty_ds.stub(:new? => true, :changed? => false, :content_changed? => false, :content => nil)
+        @new_empty_ds.stub(:new? => true, :changed? => false, :content_changed? => false, :content => nil, :dsCreateDate => '12345')
         @existing_ds = double(Rubydora::Datastream)
-        @existing_ds.stub(:new? => false, :changed? => false, :content_changed? => false, :content => 'YYY')
+        @existing_ds.stub(:new? => false, :changed? => false, :content_changed? => false, :content => 'YYY', :dsCreateDate => '12345')
         @changed_attr_ds = double(Rubydora::Datastream)
-        @changed_attr_ds.stub(:new? => false, :changed? => true, :content_changed? => false, :content => 'YYY')
+        @changed_attr_ds.stub(:new? => false, :changed? => true, :content_changed? => false, :content => 'YYY', :dsCreateDate => '12345')
         @changed_ds = double(Rubydora::Datastream)
-        @changed_ds.stub(:new? => false, :changed? => true, :content_changed? => true, :content => 'ZZZ')
+        @changed_ds.stub(:new? => false, :changed? => true, :content_changed? => true, :content => 'ZZZ', :dsCreateDate => '2012-01-02:05:15:45.100Z')
         @changed_empty_ds = double(Rubydora::Datastream)
-        @changed_empty_ds.stub(:new? => false, :changed? => true, :content_changed? => true, :content => nil)
+        @changed_empty_ds.stub(:new? => false, :changed? => true, :content_changed? => true, :content => nil, :dsCreateDate => '12345')
 
       end
       it "should save a new datastream with content" do
@@ -266,6 +266,8 @@ describe Rubydora::DigitalObject do
         @object.stub(:datastreams) { { :changed_ds => @changed_ds } }
         @changed_ds.should_receive(:save)
         @object.save
+        # object date should be canonicalized and updated
+        @object.lastModifiedDate.should == '2012-01-02:05:15:45.1Z'
       end
 
       it "should save a datastream whose attributes have changed" do

--- a/spec/lib/integration_test_spec.rb
+++ b/spec/lib/integration_test_spec.rb
@@ -175,6 +175,18 @@ describe "Integration testing against a live Fedora repository", :integration =>
     ds.content
   end
 
+  it "should cache object's lastModifiedDate from ds changes" do
+    @repository.ping.should == true
+    obj = @repository.find_or_initialize('test:1')
+    obj.save
+    obj.label = "abc"
+    obj.datastreams["my_ds"].content = "XXX"
+    obj.save
+    obj.label = "123"
+    obj.save
+  end
+
+
   describe "with transactions" do
     it "should work on ingest" do
        @repository.find('transactions:1').delete rescue nil


### PR DESCRIPTION
cam156's issue in sufia should be fixed in master, but this would keep the cached lastModifiedDate current and avoid extra calls for ds profiles.
