### PR TITLE
Ensure datastream timestamp is valid before using it.

### DIFF
--- a/lib/rubydora/digital_object.rb
+++ b/lib/rubydora/digital_object.rb
@@ -283,7 +283,9 @@ module Rubydora
       mod_time = memo_time
       self.datastreams.select { |dsid, ds| ds.changed? }.each do |dsid, ds|
         ds.save
-        mod_time = ProfileParser.canonicalize_date(ds.dsCreateDate)
+        if ds.dsCreateDate
+          mod_time = ProfileParser.canonicalize_date(ds.dsCreateDate)
+        end
       end
       mod_time
     end

--- a/spec/lib/digital_object_spec.rb
+++ b/spec/lib/digital_object_spec.rb
@@ -269,6 +269,16 @@ describe Rubydora::DigitalObject do
         # object date should be canonicalized and updated
         @object.lastModifiedDate.should == '2012-01-02:05:15:45.1Z'
       end
+      
+      it "should not set lastModifiedDate if the before_save callback is false" do
+        @object.stub(:datastreams) { { :changed_ds => @changed_ds } }
+        @changed_ds.should_receive(:dsCreateDate).and_return(nil)
+        @changed_ds.should_receive(:save)
+        @object.should_not_receive(:lastModifiedDate=)
+        @object.save
+        # object date should be unchanged from its original value
+        @object.lastModifiedDate.should == '2011-01-02:05:15:45.1Z'
+      end
 
       it "should save a datastream whose attributes have changed" do
         @object.stub(:datastreams) { { :changed_attr_ds => @changed_attr_ds } }


### PR DESCRIPTION
A datastream may not be saved (e.g. callback returns false) in which
case its dsCreateDate is nil.  Don't try to parse a time out of the nil
value.
